### PR TITLE
Don’t use protocol-relative URL in site.url

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,7 +6,7 @@ reading_time:     false # if true, shows the estimated reading time for a post
 words_per_minute: 200
 logo:             images/logo.png # logo visible in the topbar
 
-url: //openbve-project.net
+url: https://openbve-project.net
 
 # draw your top menu here
 # each item must have a title and a url.


### PR DESCRIPTION
http://openbve-project.net/ redirects to https://openbve-project.net/ anyway. This URL is used the RSS feed (if I decipher correctly how this site works), which ends up in desktop feed readers, which may not be able to interpret protocol-relative links (once the feed item has been downloaded and saved, there’s no protocol anymore to be relative to), causing rendering issues (e.g. in Thunderbird, the “Website” link in the header is missing, and the `<a>` elements in the “This post was originally published by…” line lack `href` attributes and thus aren’t clickable).